### PR TITLE
Support TopBar insets (for status bar)

### DIFF
--- a/src/components/navigation/TopBar/TopBar.tsx
+++ b/src/components/navigation/TopBar/TopBar.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 import { View } from 'react-native'
+import { useSafeArea } from 'react-native-safe-area-context'
 import { useStyles } from '../../../theme'
 import { shameStyles } from '../../../theme/shame-styles'
 import { IconName } from '../../icons/Icon/Icon'
@@ -48,11 +49,11 @@ export const TopBar: React.FC<TopBarProps> = ({
   transparent = false,
   actions,
 }) => {
+  const insets = useSafeArea()
   const styles = useStyles(theme => ({
     root: {
       flexDirection: 'row',
       backgroundColor: theme.colors.fill.background.lighter,
-      height,
       alignItems: 'center',
       ...theme.elevation.z4,
     },
@@ -71,7 +72,13 @@ export const TopBar: React.FC<TopBarProps> = ({
   )
 
   return (
-    <View style={[styles.root, transparent ? styles.transparentRoot : null]}>
+    <View
+      style={[
+        styles.root,
+        transparent ? styles.transparentRoot : null,
+        { paddingTop: insets.top, height: insets.top + height },
+      ]}
+    >
       {iconStart !== 'none' ? (
         <Box paddingX="xSmall">
           <IconButton icon={iconStart} onClick={onIconStartClick} />

--- a/src/navigation/NavigationContainer.tsx
+++ b/src/navigation/NavigationContainer.tsx
@@ -30,13 +30,11 @@ export const NavigationContainer = <Schema extends NavigationSchema>({
   ])
   const linkingOptions = schema ? buildReactNavigationLinkingOptions() : undefined
 
-  return (
-    <RNNavigationContainer independent linking={linkingOptions}>
-      {ReactNavigationTree ? (
-        <ReactNavigationTree />
-      ) : (
-        <DummyNavigationProvider>{children}</DummyNavigationProvider>
-      )}
+  return ReactNavigationTree ? (
+    <RNNavigationContainer linking={linkingOptions}>
+      <ReactNavigationTree />
     </RNNavigationContainer>
+  ) : (
+    <DummyNavigationProvider>{children}</DummyNavigationProvider>
   )
 }


### PR DESCRIPTION
**IMPORTANT: Review after Navigation branch.**

TopBar now extends itself to go below status bar on Android/iOS.
Also removed React Navigation context when having no Navigation in app.

Tested with both Navigation On/Off.